### PR TITLE
fix: remove symbol visibility settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,8 @@ project(docparser VERSION 1.0.0 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# 在顶层CMakeLists.txt中添加
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
-
 # 安全编译选项
-add_compile_options(-fstack-protector-strong -D_FORTITY_SOURCE=1 -fvisibility=hidden)
+add_compile_options(-fstack-protector-strong -D_FORTITY_SOURCE=1)
 add_link_options(-z noexecstack -pie -fPIC)
 
 # 设置安装路径

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+docparser (1.0.16) unstable; urgency=medium
+
+  * remove symbol visibility settings
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Wed, 15 Jan 2025 18:00:49 +0800
+
 docparser (1.0.15) unstable; urgency=medium
 
   * use so name


### PR DESCRIPTION
- Remove CMAKE_CXX_VISIBILITY_PRESET hidden
- Remove CMAKE_VISIBILITY_INLINES_HIDDEN
- Remove -fvisibility=hidden compile option

This change allows symbols to be visible by default in the shared library.

Log: tag 1.0.16