### PR TITLE
fix: improve file conversion fallback logic for truncated files

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+docparser (1.0.24) unstable; urgency=medium
+
+  * improve file conversion fallback logic for truncated files
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 28 Nov 2025 16:14:02 +0800
+
 docparser (1.0.23) unstable; urgency=medium
 
   * add defensive checks in excel formula evaluation


### PR DESCRIPTION
Refactored the file conversion logic to:
1. Split the truncation handling into two separate functions
2. First attempt conversion with original file extension
3. Only fallback to similar extensions if primary conversion fails
4. Removed duplicate error logging and simplified control flow
5. Improved code organization and separation of concerns

The changes ensure proper fallback behavior when processing files with different extensions and maintains cleaner error handling. Previously, the code would unconditionally try similar extensions even when the primary conversion succeeded.

Influence:
1. Test with files having correct extensions that should convert successfully
2. Test with files needing fallback to similar extensions
3. Verify truncation behavior works correctly for both cases
4. Check error cases where neither primary nor fallback extensions work
5. Validate truncation markers are added correctly

fix: 改进截断文件转换的回退逻辑

重构文件转换逻辑：
1. 将截断处理拆分为两个独立函数
2. 首先尝试使用原始文件扩展名进行转换
3. 仅当主转换失败时才回退到类似扩展名
4. 移除重复的错误日志记录并简化控制流
5. 改进代码组织和关注点分离

这些改动确保在处理不同扩展名文件时有正确的回退行为，并保持更清晰的错误处
理。之前的代码会在主转换成功后仍无条件尝试类似扩展名。

Influence:
1. 测试使用应能成功转换的正确扩展名文件
2. 测试需要回退到类似扩展名的文件
3. 验证两种情况的截断行为是否正确
4. 检查主转换和回退扩展名都无效的错误情况
5. 验证截断标记是否正确添加