### PR TITLE
fix(cmake): drop -pie from global link options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # 安全编译选项
 add_compile_options(-fstack-protector-strong -D_FORTITY_SOURCE=1)
-add_link_options(-z noexecstack -pie -fPIC)
+add_link_options(-z noexecstack -fPIC)
 
 # 设置安装路径
 include(GNUInstallDirs)


### PR DESCRIPTION
-pie forces building PIE executables and breaks shared library linking on ppc64le, resulting in undefined reference to main.