### PR TITLE
feat(tests): add Qt5/Qt6 compatibility support

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,11 @@
 set(CMAKE_AUTOMOC ON)
-find_package(Qt6 REQUIRED COMPONENTS Core Test)
-find_package(Dtk6 REQUIRED COMPONENTS Core)
+if(Qt6_FOUND)
+    find_package(Qt6 REQUIRED COMPONENTS Core Test)
+    find_package(Dtk6 REQUIRED COMPONENTS Core)
+else()
+    find_package(Qt5 REQUIRED COMPONENTS Core Test)
+    find_package(DtkCore REQUIRED)
+endif()
 
 # Enable testing
 enable_testing()
@@ -25,16 +30,16 @@ add_executable(docparser_autotest ${AUTOTEST_SOURCES})
 target_link_libraries(docparser_test
     PRIVATE
         docparser
-        Qt6::Core
-        Dtk6::Core
+        $<IF:$<BOOL:${Qt6_FOUND}>,Qt6::Core,Qt5::Core>
+        $<IF:$<BOOL:${Qt6_FOUND}>,Dtk6::Core,Dtk::Core>
 )
 
 # 链接自动化测试所需的库
 target_link_libraries(docparser_autotest
     PRIVATE
         docparser
-        Qt6::Core
-        Qt6::Test
+        $<IF:$<BOOL:${Qt6_FOUND}>,Qt6::Core,Qt5::Core>
+        $<IF:$<BOOL:${Qt6_FOUND}>,Qt6::Test,Qt5::Test>
 )
 
 # 设置包含目录

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -76,7 +76,11 @@ int main(int argc, char **argv)
         if (fromEncoding.toLower() != "utf-8") {
             auto in = QByteArray::fromStdString(content);
             QByteArray out;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
             Dtk::Core::DTextEncoding::convertTextEncodingEx(in, out, "utf-8", fromEncoding);
+#else
+            Dtk::Core::DTextEncoding::convertTextEncoding(in, out, "utf-8", fromEncoding);
+#endif
             content = out.toStdString();
         }
 


### PR DESCRIPTION
- Add conditional package finding for Qt6 or Qt5 dependencies
- Use generator expressions to link appropriate Qt version libraries
- Add preprocessor conditionals for Qt6 vs Qt5 API usage
- Maintain backward compatibility with both Qt frameworks