### PR TITLE
feat: add license information for Excel libraries and test data

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -28,6 +28,19 @@ Files: 3rdparty/libs/*
 Copyright: 2018 Dmitry Ryutov
 License: MIT
 
+Files: 3rdparty/libs/fileext/excel/xlsxio/*
+Copyright: 2016 Brecht Sanders
+License: MIT
+
+Files: 3rdparty/libs/fileext/excel/libxls/*
+Copyright: 2004 Komarov Valery, 2006 Christophe Leitienne, 2008-2017 David Hoerl, 2013 Bob Colbert, 2013-2018 Evan Miller
+License: BSD-2-Clause
+
 Files: 3rdparty/utils/*
 Copyright: None
 License: MIT
+
+# test data
+Files: tests/file/*
+Copyright: None
+License: CC0-1.0

--- a/LICENSES/BSD-2-Clause.txt
+++ b/LICENSES/BSD-2-Clause.txt
@@ -1,0 +1,24 @@
+BSD 2-Clause License
+
+Copyright (c) <year>, <copyright holder>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,9 @@ Build-Depends:
  libxml2-dev,
  uuid-dev,
  libtinyxml2-dev,
- libmagic-dev
+ libmagic-dev,
+ libexpat1-dev,
+ libminizip-dev
 Standards-Version: 4.3.0
 
 Package: libdocparser


### PR DESCRIPTION
- Add MIT license information for xlsxio library files
- Add BSD-2-Clause license information for libxls library files
- Add CC0-1.0 license for test data files
- Update build dependencies to include libexpat1-dev and libminizip-dev Log: feat: add license information for Excel libraries and test data Task: https://pms.uniontech.com/task-view-388905.html